### PR TITLE
Update to 1.16.4

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -27,6 +27,8 @@ logoFile="examplemod.png" #optional
 credits="Thanks for this example mod goes to Java" #optional
 # A text field displayed in the mod UI
 authors="Lothrazar" #optional
+# License
+license="The MIT License (MIT)"
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 Plants each only grow in a few biomes


### PR DESCRIPTION
- Add license property to mods.toml

This should resolve the "Missing license information in file Mod File" issue one gets if one tries to run the mod on 1.16.4.
